### PR TITLE
feat: :sparkles: Add address endpoint

### DIFF
--- a/internal/models/address.go
+++ b/internal/models/address.go
@@ -1,0 +1,16 @@
+package models
+
+type Address struct {
+	Address1       string
+	Address2       string
+	BuildingName   string
+	BuildingNumber string
+	Country        string
+	FlatNumber     string
+	Postcode       string
+	State          string
+	Street         string
+	SubStreet      string
+	Town           string
+	Status         string
+}

--- a/internal/models/transaction.go
+++ b/internal/models/transaction.go
@@ -8,15 +8,16 @@ import (
 
 type Transaction struct {
 	Shared
-	ID           *string `json:"id" path:"txID" gorm:"primaryKey;column:id" description:"Transaction ID" example:"cq1qh5c23amg0302nqv0"`
-	EventID      *string `json:"event_id" gorm:"column:event_id" description:"Event ID associated with transaction" example:"cpkz6tb23amg03015m70"`
-	Name         *string `json:"name" description:"Transaction's name" example:"My Transaction"`
-	TenantName   *string `json:"tenant_name" gorm:"column:tenant_name" description:"Name of tenant" example:"Thirdfort Limited"`
-	ConsumerName *string `json:"consumer_name" gorm:"column:actor_name" description:"Consumer's name" example:"Bob Bobson"`
-	Ref          *string `json:"ref" gorm:"column:ref" description:"Transaction reference" example:"MyTransaction01"`
-	Status       string  `json:"status" description:"Status of the transaction" example:"not_started" enum:"not_started,in_progress,completed,cancelled"`
-	ActorID      *string `json:"-" gorm:"primaryKey;column:actor_id"`
-	Metadata     *string `json:"metadata" gorm:"type:jsonb" description:"Transaction Metadata from PA"`
+	ID           *string  `json:"id" path:"txID" gorm:"primaryKey;column:id" description:"Transaction ID" example:"cq1qh5c23amg0302nqv0"`
+	EventID      *string  `json:"event_id" gorm:"column:event_id" description:"Event ID associated with transaction" example:"cpkz6tb23amg03015m70"`
+	Name         *string  `json:"name" description:"Transaction's name" example:"My Transaction"`
+	TenantName   *string  `json:"tenant_name" gorm:"column:tenant_name" description:"Name of tenant" example:"Thirdfort Limited"`
+	ConsumerName *string  `json:"consumer_name" gorm:"column:actor_name" description:"Consumer's name" example:"Bob Bobson"`
+	Ref          *string  `json:"ref" gorm:"column:ref" description:"Transaction reference" example:"MyTransaction01"`
+	Status       string   `json:"status" description:"Status of the transaction" example:"not_started" enum:"not_started,in_progress,completed,cancelled"`
+	ActorID      *string  `json:"-" gorm:"primaryKey;column:actor_id"`
+	Metadata     *string  `json:"metadata" gorm:"type:jsonb" description:"Transaction Metadata from PA"`
+	Address      *Address `json:"address" gorm:"type:jsonb" description:"Address for transaction"`
 }
 
 type TransactionResponse struct {
@@ -28,6 +29,7 @@ type TransactionResponse struct {
 	Ref          string    `json:"ref" description:"Transaction reference" example:"MyTransaction01"`
 	Status       string    `json:"status" description:"Status of the transaction" example:"not_started" enum:"not_started,in_progress,completed,cancelled"`
 	CreatedAt    time.Time `json:"created_at" description:"Transaction creation time" example:"2021-07-01T12:00:00Z"`
+	Address      *Address  `json:"address" gorm:"type:jsonb" description:"Address for transaction"`
 }
 
 func (a *Transaction) ToResponse() *TransactionResponse {

--- a/internal/repositories/address.go
+++ b/internal/repositories/address.go
@@ -28,6 +28,12 @@ func (s *Store) UpdateAddress(ctx context.Context, transactionID string, newAddr
 		return nil, errors.New("no transaction")
 	} else {
 		txn.Address = &newAddress
+
+		res := db.WithContext(ctx).Save(txn)
+		if res.Error != nil {
+			return nil, res.Error
+		}
+
 		return txn.Address, nil
 	}
 }

--- a/internal/repositories/address.go
+++ b/internal/repositories/address.go
@@ -1,0 +1,33 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/thirdfort/thirdfort-go-code-review/internal/models"
+)
+
+func (s *Store) FindAddress(ctx context.Context, transactionId string) (*models.Address, error) {
+	txn := models.Transaction{}
+	s.db.Where(fmt.Sprintf("id = %v", transactionId)).First(&txn)
+
+	if txn.Address == nil {
+		return nil, errors.New("no transaction")
+	} else {
+		return txn.Address, nil
+	}
+}
+
+func (s *Store) UpdateAddress(ctx context.Context, transactionID string, newAddress models.Address) (*models.Address, error) {
+	db := s.db
+	txn := models.Transaction{}
+	db.Where(fmt.Sprintf("id = %v", transactionID)).First(&txn)
+
+	if txn.Address == nil {
+		return nil, errors.New("no transaction")
+	} else {
+		txn.Address = &newAddress
+		return txn.Address, nil
+	}
+}

--- a/internal/repositories/store.go
+++ b/internal/repositories/store.go
@@ -26,6 +26,7 @@ type DataStore interface {
 	UpdateTransaction(ctx context.Context, transaction *models.Transaction) (*models.Transaction, error)
 	GetTransaction(ctx context.Context, transaction *models.Transaction) (*models.Transaction, error)
 	GetTransactions(ctx context.Context, transaction *models.Transaction) ([]models.Transaction, error)
+	FindAddress(ctx context.Context, transactionId string) (*models.Address, error)
 }
 
 // We'll inject this dependency into the handlers and feed it down to the repositories where it'll be used

--- a/internal/service/address.go
+++ b/internal/service/address.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/thirdfort/thirdfort-go-code-review/internal/models"
+)
+
+func FindAddress(tx_id string) (models.Address, error) {
+	address, err := MyService.DataStore.FindAddress(context.TODO(), tx_id)
+	return *address, err
+}
+
+func UpdateAddress(transactionId string, newAddr models.Address) (*models.Address, error) {
+
+	address, _ := FindAddress(transactionId)
+
+	if address.Status == "completed" {
+		return nil, errors.New("Adddress is already complete")
+	} else if address.Status == "pending" || address.Status == "accepted" {
+		// update address
+		MyService.DataStore.GetStore().UpdateAddress(context.TODO(), transactionId, newAddr)
+		return &newAddr, nil
+	}
+	return nil, nil
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -10,6 +10,8 @@ import (
 	"github.com/thirdfort/thirdfort-go-code-review/internal/repositories"
 )
 
+var MyService Service
+
 type MainService interface {
 	CheckTxOwnership(ctx context.Context, transactionID string) error
 	GetActor(ctx context.Context) (*models.Actor, error)

--- a/internal/service/web/address.go
+++ b/internal/service/web/address.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/thirdfort/thirdfort-go-code-review/internal/models"
+	"github.com/thirdfort/thirdfort-go-code-review/internal/service"
+)
+
+func FindAddress(c *gin.Context, req *models.Transaction) (*models.TransactionResponse, error) {
+	LogAddressRequest(c, req.ID)
+	addr, err := service.FindAddress(*req.ID)
+	if err != nil {
+		panic(err)
+	}
+	return &models.TransactionResponse{Address: &addr}, nil
+}
+
+func UpdateAddress(c *gin.Context, req *models.Transaction) (*models.TransactionResponse, error) {
+	LogAddressRequest(c, req.ID)
+	addr, err := service.UpdateAddress(*req.ID, *req.Address)
+	if err != nil {
+		panic(err)
+	}
+	return &models.TransactionResponse{Address: addr}, nil
+}
+
+func LogAddressRequest(c *gin.Context, txID *string) context.Context {
+	ctx := getCtx(c)
+
+	if txID != nil {
+		fmt.Printf("{transactionID: %s}", *txID)
+	}
+	fmt.Printf("{Req: {method: %s, path: %s}}", c.Request.Method, c.Request.URL.Path)
+	return ctx
+}

--- a/internal/service/web/v1.go
+++ b/internal/service/web/v1.go
@@ -11,6 +11,10 @@ func (s *WebService) setV1Routes() {
 	// Transaction routes
 	txRouter := v1Router.Group("/transaction", "transaction", "Transaction endpoints")
 	s.transactionRoutes(txRouter)
+
+	// Address Routes
+	addressRouter := v1Router.Group("/address", "address", "Address endpoints")
+	s.AddressRoutes(addressRouter)
 }
 
 func (s *WebService) transactionRoutes(router *fizz.RouterGroup) {
@@ -28,4 +32,16 @@ func (s *WebService) transactionRoutes(router *fizz.RouterGroup) {
 		fizz.ID("PatchTransactionByID"),
 		fizz.Summary("GET Transaction by ID"),
 	}, tonic.Handler(s.PatchTransaction, 200))
+}
+
+func (s *WebService) AddressRoutes(router *fizz.RouterGroup) {
+	router.Handle("", "GET", []fizz.OperationOption{
+		fizz.ID("GetAddressByID"),
+		fizz.Summary("GET Address by ID"),
+	}, tonic.Handler(FindAddress, 200))
+
+	router.Handle("", "PATCH", []fizz.OperationOption{
+		fizz.ID("PatchAddressByID"),
+		fizz.Summary("PATCH Address by ID"),
+	}, tonic.Handler(UpdateAddress, 200))
 }


### PR DESCRIPTION
We require an address to be associated with an existing transaction.

**Acceptance criteria:**
Add functionality to get and update existing address by id. Address status is `pending` before updating, `accepted` after being modified and `completed` once processed, at which point it can’t be modified anymore. 

Solution:
- `GET address` (by transaction id)
- `PATCH address` (by transaction id)